### PR TITLE
Updated apiKey -> apiAccessToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ These examples show the most common features of the `MemClient`. You'll find mor
 import { MemClient } from "@mem-labs/mem-node";
 
 const memClient = new MemClient({
-  apiKey: "<API_KEY_HERE>"
+  apiAccessToken: "<Replace this with your access token>"
 });
 ```
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@mem-labs/mem-node",
   "description": "Official Node.js client for the Mem API.",
   "author": "Mem Labs, Inc. <engineering@mem.ai>",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "main": "dist/entry.js",
   "types": "dist/entry.d.ts",
   "license": "ISC",

--- a/src/mem-client/__tests__/MemClient.test.ts
+++ b/src/mem-client/__tests__/MemClient.test.ts
@@ -9,7 +9,7 @@ import { MemClient } from "../MemClient";
 const mockApiKey = "mock-api-key";
 
 const getMockClient = () => {
-  const mockClient = new MemClient({ apiKey: mockApiKey });
+  const mockClient = new MemClient({ apiAccessToken: mockApiKey });
 
   return mockClient;
 };

--- a/src/mem-client/constants.ts
+++ b/src/mem-client/constants.ts
@@ -1,1 +1,3 @@
 export const defaultMemApiEndpoint = "https://api.mem.ai/graphql";
+
+export const defaultMemAuthorizationScheme = `ApiAccessToken`;

--- a/src/mem-client/methods/healthCheck.ts
+++ b/src/mem-client/methods/healthCheck.ts
@@ -7,7 +7,7 @@ export const memClientHealthCheck =
   /**
    * Returns true if the client is are able to successfully contact the server.
    *
-   * Useful for verifying that your `apiKey` is working successfully.
+   * Useful for verifying that your `apiAccessToken` is working successfully.
    */
   async () => {
     const result = await memClient.graphqlRequest(HealthCheckDocument);

--- a/src/mem-client/types.ts
+++ b/src/mem-client/types.ts
@@ -3,5 +3,5 @@ import { LogLevel } from "../utils/logger/types";
 export interface MemClientConfig {
   apiEndpoint?: string;
   logLevel?: LogLevel;
-  apiKey: string;
+  apiAccessToken: string;
 }

--- a/src/services/mock-server/graphql/handleErrors.ts
+++ b/src/services/mock-server/graphql/handleErrors.ts
@@ -1,0 +1,32 @@
+import { GraphQLError } from "graphql";
+
+import { ClientRequestError } from "../../../utils/errors/request";
+
+export interface GraphQLClientError {
+  message?: string;
+  response: {
+    errors: GraphQLError[];
+  };
+}
+
+export const _handleGraphqlRequestErrors = ({ err }: { err: Error | GraphQLClientError }) => {
+  if ("response" in err && "errors" in err.response) {
+    const graphqlErrors = err.response.errors;
+    const firstError = graphqlErrors[0];
+
+    /** We don't know how to handle this error, so we re-throw. */
+    if (firstError) {
+      const extensionCode: string | undefined =
+        firstError.extensions?.code ?? "CLIENT::UNKNOWN_ERROR";
+
+      throw new ClientRequestError({
+        message: `Request failed with error code: ${extensionCode}`,
+      });
+    }
+  }
+
+  /** We don't know how to handle this error, so we re-throw. */
+  throw new ClientRequestError({
+    message: `Request failed: ${err.message || JSON.stringify(err)}`,
+  });
+};

--- a/src/services/mock-server/graphql/index.ts
+++ b/src/services/mock-server/graphql/index.ts
@@ -1,0 +1,5 @@
+import { _handleGraphqlRequestErrors } from "./handleErrors";
+
+export const graphqlService = {
+  handleRequestErrors: _handleGraphqlRequestErrors,
+} as const;

--- a/src/utils/errors/request.ts
+++ b/src/utils/errors/request.ts
@@ -1,0 +1,9 @@
+import { ClientError } from "./base";
+
+export class ClientRequestError extends ClientError {
+  constructor({ message }: { message?: string } = {}) {
+    const errorMessage = message ?? "Unknown Error";
+
+    super({ message: errorMessage });
+  }
+}


### PR DESCRIPTION
I'm updating the terminology to match our authorization scheme's terminology
```
apiAccessToken: ...
```

Also added some error-handling utilities to make the thrown errors more consistent.